### PR TITLE
changed handling of getch() return value to use int for storage

### DIFF
--- a/bionics.cpp
+++ b/bionics.cpp
@@ -824,7 +824,7 @@ bool player::install_bionics(game *g, const it_bionic* type)
 Installing this bionic will increase your total battery capacity by 10.\n\
 Batteries are necessary for most bionics to function.  They also require a\n\
 charge mechanism, which must be installed from another CBM.");
-  char ch;
+  int ch;
   wrefresh(w.get());
   do ch = getch();
   while (ch != 'q' && ch != '\n' && ch != KEY_ESCAPE);

--- a/bionics.cpp
+++ b/bionics.cpp
@@ -846,7 +846,7 @@ charge mechanism, which must be installed from another CBM.");
  }
 
  int selection = 0;
- char ch;
+ int ch;
 
  do {
 

--- a/computer.cpp
+++ b/computer.cpp
@@ -159,7 +159,7 @@ void computer::use(game *g)
   print_line("Q - Quit and shut down");
   print_line("");
  
-  char ch;
+  int ch;
   do
    ch = getch();
   while (ch != 'q' && ch != 'Q' && (ch < '1' || ch - '1' >= options.size()));
@@ -740,7 +740,7 @@ bool computer::query_bool(const char *mes, ...)
  va_end(ap);
 // Print, appending (Y/N/Q)
  print_line((std::string(buff) += " (Y/N/Q)").c_str());
- char ret;
+ int ret;
  do ret = getch();
  while (ret != 'y' && ret != 'Y' && ret != 'n' && ret != 'N' && ret != 'q' && ret != 'Q');
  return (ret == 'y' || ret == 'Y');
@@ -761,7 +761,7 @@ char computer::query_ynq(const char *mes, ...)
  va_end(ap);
 // Print, appending (Y/N/Q)
  print_line((std::string(buff) += " (Y/N/Q)").c_str());
- char ret;
+ int ret;
  do ret = getch();
  while (ret != 'y' && ret != 'Y' && ret != 'n' && ret != 'N' && ret != 'q' && ret != 'Q');
  return ret;

--- a/construction.cpp
+++ b/construction.cpp
@@ -199,7 +199,7 @@ void game::construction_menu()
 
  bool update_info = true;
  int select = 0;
- char ch;
+ int ch;
 
  inventory total_inv;
  total_inv.form_from_map(m, u.pos, PICKUP_RANGE);

--- a/crafting.cpp
+++ b/crafting.cpp
@@ -690,7 +690,7 @@ void game::craft()
  int line = 0, xpos, ypos;
  bool redraw = true;
  bool done = false;
- char ch;
+ int ch;
 
  inventory crafting_inv(crafting_inventory(m, u));
 

--- a/defense.cpp
+++ b/defense.cpp
@@ -417,7 +417,7 @@ void defense_game::setup()
  refresh_setup(w, selection);
 
  while (true) {
-  char ch = input();
+  int ch = input();
  
   if (ch == 'S') {
    if (!zombies && !specials && !spiders && !triffids && !robots && !subspace) {
@@ -787,7 +787,7 @@ void defense_game::caravan(game *g)
  bool cancel = false;
  while (!done) {
 
-  char ch = input();
+  int ch = input();
   switch (ch) {
    case '?':
     popup_top("\

--- a/game.cpp
+++ b/game.cpp
@@ -232,7 +232,7 @@ http://github.com/zaimoni/Cataclysm .");
  }
 #endif
  int sel1 = 0, sel2 = 1, layer = 1;
- char ch;
+ int ch;
  bool start = false;
 
 // Load MOTD and store it in a string
@@ -1041,11 +1041,11 @@ void game::process_missions()
 
 void game::get_input()
 {
- char ch = input(); // See keypress.h - translates keypad and arrows to vikeys
+ int ch = input(); // See keypress.h - translates keypad and arrows to vikeys
 
  action_id act = keys.translate(ch);
  if (!act) {
-  if (ch != ' ' && ch != KEY_ESCAPE && ch != '\n') messages.add("Unknown command: '%c'", ch);
+  if (ch != ' ' && ch != KEY_ESCAPE && ch != '\n') messages.add("Unknown command: '%c'", char(ch));
   return;
  }
 
@@ -2085,7 +2085,7 @@ faction* game::list_factions(std::string title)
  }
  mvwprintz(w_info, linenum, 0, c_white, desc.c_str());
  wrefresh(w_info);
- char ch;
+ int ch;
  do {
   ch = input();
   switch ( ch ) {
@@ -2148,7 +2148,7 @@ void game::list_missions()
 
  WINDOW *w_missions = newwin(VIEW, SCREEN_WIDTH, 0, 0);
  int tab = 0, selection = 0;
- char ch;
+ int ch;
  do {
   werase(w_missions);
   draw_tabs(w_missions, tab, labels);
@@ -3472,7 +3472,7 @@ void game::open()
  bool didit = false;
  mvwprintw(w_terrain, 0, 0, "Open where? (hjklyubn) ");
  wrefresh(w_terrain);
- char ch = input();
+ int ch = input();
  point open(get_direction(ch));
  if (open.x != -2) {
   int vpart;
@@ -3514,7 +3514,7 @@ void game::close()
  bool didit = false;
  mvwprintw(w_terrain, 0, 0, "Close where? (hjklyubn) ");
  wrefresh(w_terrain);
- char ch = input();
+ int ch = input();
  point close(get_direction(ch));
  if (-2 == close.x) { messages.add("Invalid direction."); return; }
  close += u.pos;
@@ -3546,7 +3546,7 @@ void game::smash()
  int smashskill = int(u.str_cur / 2.5 + u.weapon.type->melee_dam);
  mvwprintw(w_terrain, 0, 0, "Smash what? (hjklyubn) ");
  wrefresh(w_terrain);
- char ch = input();
+ int ch = input();
  if (ch == KEY_ESCAPE) {
   messages.add("Never mind.");
   return;
@@ -3698,7 +3698,7 @@ void game::examine()
  }
  mvwprintw(w_terrain, 0, 0, "Examine where? (Direction button) ");
  wrefresh(w_terrain);
- char ch = input();
+ int ch = input();
  if (ch == KEY_ESCAPE || ch == 'e' || ch == 'q') return;
  point exam(get_direction(ch));
  if (exam.x == -2) {
@@ -3906,7 +3906,7 @@ point game::look_around()
 {
  draw_ter();
  point l(u.pos);
- char ch;
+ int ch;
  WINDOW* w_look = newwin(VIEW-SEE, SCREEN_WIDTH-(SEE * 2 + 8), SEE, SEE * 2 + 8);
  wborder(w_look, LINE_XOXO, LINE_XOXO, LINE_OXOX, LINE_OXOX,
                  LINE_OXXO, LINE_OOXX, LINE_XXOO, LINE_XOOX );

--- a/game.cpp
+++ b/game.cpp
@@ -1465,7 +1465,7 @@ void game::death_screen()
 
  wrefresh(w_death);
  refresh();
- char ch;
+ int ch;
  do ch = getch();
  while(ch != ' ' && ch != '\n' && ch != KEY_ESCAPE);
  delwin(w_death);
@@ -4122,7 +4122,7 @@ void game::pickup(const point& pt, int min)
  constexpr const int maxitems = 9;	 // Number of items to show at one time.
  std::vector <item> here = from_veh? veh->parts[veh_part].items : m.i_at(pt);
  std::vector<bool> getitem(here.size(),false);
- char ch = ' ';
+ int ch = ' ';
  int start = 0, cur_it, iter;
  int new_weight = u.weight_carried(), new_volume = u.volume_carried();
  bool update = true;
@@ -5022,7 +5022,7 @@ void game::chat()
   mvwprintz(w, available.size() + 1, 1, c_white, "%d: Cancel",
             available.size() + 1);
   wrefresh(w);
-  char ch;
+  int ch;
   do {
    ch = getch();
   } while (ch < '1' || ch > '1' + available.size());

--- a/help.cpp
+++ b/help.cpp
@@ -423,7 +423,7 @@ easily drop unwanted items on the floor.");
   case '1': {
    erase();
    int offset = 1;
-   char ch = ' ';
+   int ch = ' ';
    bool changed_keymap = false;
    bool needs_refresh = true;
    do {
@@ -491,7 +491,7 @@ easily drop unwanted items on the floor.");
    erase();
    auto& OPTIONS = option_table::get();
    int offset = 1;
-   char ch = ' ';
+   int ch = ' ';
    bool changed_options = false;
    bool needs_refresh = true;
    do {

--- a/help.cpp
+++ b/help.cpp
@@ -23,7 +23,7 @@ void game::help()
 // the number of options we can both display, and show a lower-case key as a menu entry trigger
 #define MENU_SPAN ((VIEW-1)<('z'-'a') ? VIEW : ('z'-'a')+1)
 
- char ch;
+ int ch;
  do {
   erase();
   mvprintz(0, 38, c_red, "HELP");
@@ -469,7 +469,7 @@ easily drop unwanted items on the floor.");
       mvprintz(i, 1, c_white, ":");
      }
      refresh();
-     char actch = getch();
+     int actch = getch();
      if (actch >= 'a' && actch < 'a' + MENU_SPAN && actch - 'a' + offset < NUM_ACTIONS) {
       action_id act = action_id(actch - 'a' + offset);
       if (ch == '-' && query_yn("Clear keys for %s?",action_name(act).c_str())){
@@ -541,7 +541,7 @@ easily drop unwanted items on the floor.");
       mvprintz(i, 1, c_white, ":");
      }
      refresh();
-     char actch = getch();
+     int actch = getch();
      if (actch >= 'a' && actch < 'a' + MENU_SPAN && actch - 'a' + offset < NUM_OPTION_KEYS) {
 	 const auto opt = option_key(actch - 'a' + offset);
 	 switch (option_table::type_code(opt))

--- a/inventory_ui.cpp
+++ b/inventory_ui.cpp
@@ -85,7 +85,7 @@ char game::inv(std::string title)
 {
  static const std::vector<char> null_vector;
  constexpr const int maxitems = 20;	// Number of items to show at one time.
- char ch = '.';
+ int ch = '.';
  int start = 0, cur_it;
  u.sort_inv();
  u.inv.restack(&u);
@@ -159,7 +159,7 @@ std::vector<item> game::multidrop()
 // Gun, ammo, weapon, armor, food, tool, book, other
  const auto firsts = find_firsts(u.inv);
 
- char ch = '.';
+ int ch = '.';
  int start = 0;
  size_t cur_it = 0;
  do {

--- a/item.cpp
+++ b/item.cpp
@@ -962,7 +962,7 @@ int item::pick_reload_ammo(const player &u, bool interactive) const
  if (am.size() > 1 && interactive) {// More than one option; list 'em and pick
   WINDOW* w_ammo = newwin(am.size() + 1, SCREEN_WIDTH, 0, 0);
   if (charges == 0) {
-   char ch;
+   int ch;
    clear();
    mvwprintw(w_ammo, 0, 0, "\
 Choose ammo type:         Damage     Armor Pierce     Range     Accuracy");

--- a/iuse.cpp
+++ b/iuse.cpp
@@ -67,7 +67,7 @@ static void _display_hp(WINDOW* w, player* p, int curhp, int i)
 
 static bool _get_heal_target(player* p, item* it, hp_part& healed)
 {
-    char ch;
+    int ch;
     do {
         ch = getch();
         if (ch == '1')
@@ -869,7 +869,7 @@ void iuse::two_way_radio(game *g, player *p, item *it, bool t)
  mvwprintz(w, 3, 1, c_white, "3: General S.O.S.");
  mvwprintz(w, 4, 1, c_white, "0: Cancel");
  wrefresh(w);
- char ch = getch();
+ int ch = getch();
  if (ch == '1') {
   p->moves -= 300;
   faction* fac = g->list_factions("Call for help...");

--- a/keypress.cpp
+++ b/keypress.cpp
@@ -5,9 +5,9 @@
 keymap<action_id> keys;
 #endif
 
-long input()
+int input()
 {
- long ch = getch();
+ int ch = getch();
  switch (ch) {
   case KEY_UP:    return 'k';
   case KEY_LEFT:  return 'h';

--- a/keypress.cpp
+++ b/keypress.cpp
@@ -18,7 +18,7 @@ int input()
  }
 }
 
-void get_direction(int &x, int &y, char ch)
+void get_direction(int &x, int &y, int ch)
 {
  x = 0;
  y = 0;
@@ -64,9 +64,9 @@ void get_direction(int &x, int &y, char ch)
 }
 
 #ifndef SOCRATES_DAIMON
-point get_direction(char ch)
+point get_direction(int ch)
 {
- switch (keys.translate(ch)) {
+ switch (keys.translate(char(ch))) {
  case ACTION_MOVE_NW: return point(-1, -1);
  case ACTION_MOVE_NE: return point(1, -1);
  case ACTION_MOVE_W: return point(-1, 0);

--- a/keypress.h
+++ b/keypress.h
@@ -8,7 +8,7 @@
 #endif
 
 // Simple text input--translates numpad to vikeys
-long input();
+int input();
 // If ch is vikey, x & y are set to corresponding direction; ch=='y'->x=-1,y=-1
 void get_direction(int &x, int &y, char ch);
 // Uses the keymap to figure out direction properly

--- a/keypress.h
+++ b/keypress.h
@@ -10,10 +10,10 @@
 // Simple text input--translates numpad to vikeys
 int input();
 // If ch is vikey, x & y are set to corresponding direction; ch=='y'->x=-1,y=-1
-void get_direction(int &x, int &y, char ch);
+void get_direction(int &x, int &y, int ch);
 // Uses the keymap to figure out direction properly
 #ifndef SOCRATES_DAIMON
-point get_direction(char ch);
+point get_direction(int ch);
 #endif
 
 #ifndef SOCRATES_DAIMON

--- a/newcharacter.cpp
+++ b/newcharacter.cpp
@@ -269,7 +269,6 @@ void draw_tabs(WINDOW* w)
 int set_stats(WINDOW* w, player *u, int &points)
 {
  unsigned char sel = 1;
- char ch;
 // Draw horizontal lines, with a gap for the active tab
  for (int i = 0; i < SCREEN_WIDTH; i++) {
   if (i < 4 || i > 14)
@@ -392,7 +391,7 @@ int set_stats(WINDOW* w, player *u, int &points)
   }
  
   wrefresh(w);
-  ch = input();
+  int ch = input();
   if (ch == 'j' && sel < 4)
    sel++;
   if (ch == 'k' && sel > 1)
@@ -790,7 +789,6 @@ To save this character as a template, press !.");
  
  int line = 1;
  bool noname = false;
- long ch;
 
  do {
   if (u->male) {
@@ -812,7 +810,7 @@ To save this character as a template, press !.");
    mvwprintz(w, 8, 2, c_ltgray, "Gender:");
 
   wrefresh(w);
-  ch = input();
+  int ch = input();
   if (noname) {
    mvwprintz(w, 6, 8, c_ltgray, "______________________________");
    noname = false;

--- a/npctalk.cpp
+++ b/npctalk.cpp
@@ -1666,7 +1666,7 @@ Tab key to switch lists, letters to pick items, Enter to finalize, Esc to quit\n
  bool focus_them = true;	// Is the focus on them?
  bool update = true;		// Re-draw the screen?
  int  them_off = 0, you_off = 0;// Offset from the start of the list
- char ch, help;
+ int  ch, help;
  
  do {
   if (update) {	// Time to re-draw

--- a/output.cpp
+++ b/output.cpp
@@ -327,7 +327,7 @@ bool query_yn(const char *mes, ...)
  mvwprintz(w, 1, 1, c_ltred, "%s (%s)", buff,
            (force_uc ? "Y/N - Case Sensitive" : "y/n"));
  wrefresh(w);
- char ch;
+ int ch;
  do ch = getch();
  while (ch != 'Y' && ch != 'N' && (force_uc || (ch != 'y' && ch != 'n')));
  werase(w);
@@ -393,7 +393,7 @@ std::string string_input_popup(const char *mes, ...)
  mvwputch(w, 1, posx, h_ltgray, '_');
  do {
   wrefresh(w);
-  long ch = getch();
+  int ch = getch();
   if (ch == 27) {	// Escape
    werase(w);
    wrefresh(w);
@@ -446,7 +446,7 @@ std::string string_input_popup(int max_length, const char *mes, ...)
  mvwputch(w, 1, posx, h_ltgray, '_');
  do {
   wrefresh(w);
-  long ch = getch();
+  int ch = getch();
   if (ch == 27) {	// Escape
    werase(w);
    wrefresh(w);
@@ -519,7 +519,7 @@ char popup_getkey(const char *mes, ...)
  mvwprintz(w, line_num, 1, c_white, tmp.c_str());
  
  wrefresh(w);
- char ch = getch();
+ int ch = getch();
  werase(w);
  wrefresh(w);
  delwin(w);
@@ -549,7 +549,7 @@ int menu_vec(const char *mes, const std::vector<std::string>& options)  // \todo
   mvwprintw(w, i + 2, 1, "%c: %s", (i < 9? i + '1' :
                                    (i == 9? '0' : 'a' + i - 10)),
             options[i].c_str());
- long ch;
+ int ch;
  wrefresh(w);
  int res;
  do {
@@ -630,7 +630,7 @@ void popup_top(const char *mes, ...)
  mvwprintz(w, line_num, 1, c_white, tmp.c_str());
  
  wrefresh(w);
- char ch;
+ int ch;
  do
   ch = getch();
  while(ch != ' ' && ch != '\n' && ch != KEY_ESCAPE);
@@ -685,7 +685,7 @@ void popup(const char *mes, ...)
  mvwprintz(w, line_num, 1, c_white, tmp.c_str());
  
  wrefresh(w);
- char ch;
+ int ch;
  do
   ch = getch();
  while(ch != ' ' && ch != '\n' && ch != KEY_ESCAPE);
@@ -772,7 +772,7 @@ void full_screen_popup(const char* mes, ...)
  line_num++;
  mvwprintz_noformat(w, line_num, 1, c_white, tmp.c_str());
  wrefresh(w);
- char ch;
+ int ch;
  do
   ch = getch();
  while(ch != ' ' && ch != '\n' && ch != KEY_ESCAPE);

--- a/overmap.cpp
+++ b/overmap.cpp
@@ -1195,7 +1195,7 @@ int overmap::dist_from_city(point p) const
  return distance;
 }
 
-void overmap::draw(WINDOW *w, game *g, point& curs, point& orig, char &ch, bool blink) const
+void overmap::draw(WINDOW *w, game *g, point& curs, point& orig, int ch, bool blink) const
 {
  constexpr const bool legend = true;
  constexpr const int om_w = 51;	// overmap width
@@ -1341,7 +1341,7 @@ point overmap::choose_point(game *g)    // not const due to overmap::add_note
  point curs((g->lev.x + int(MAPSIZE / 2)), (g->lev.y + int(MAPSIZE / 2)));
  curs /= 2;
  point orig(curs);
- char ch = 0;
+ int ch = 0;
  point ret(-1, -1);
  
  do {  

--- a/overmap.cpp
+++ b/overmap.cpp
@@ -689,7 +689,7 @@ point overmap::display_notes() const
  std::string title = "Notes:";
  WINDOW* w_notes = newwin(VIEW, SCREEN_WIDTH, 0, 0);
  const int maxitems = 20;	// Number of items to show at one time.
- char ch = '.';
+ int ch = '.';
  int start = 0, cur_it;
  mvwprintz(w_notes, 0, 0, c_ltgray, title.c_str());
  do{

--- a/overmap.h
+++ b/overmap.h
@@ -137,7 +137,7 @@ class overmap
   void generate(game* g, const overmap* north, const overmap* east, const overmap* south, const overmap* west);
   void generate_sub(const overmap* above);
   //Drawing
-  void draw(WINDOW *w, game *g, point& curs, point& orig, char &ch, bool blink) const;
+  void draw(WINDOW *w, game *g, point& curs, point& orig, int ch, bool blink) const;
   // Overall terrain
   void place_river(point pa, point pb);
   void place_forest();

--- a/player.cpp
+++ b/player.cpp
@@ -2916,7 +2916,7 @@ void player::power_bionics(game *g)
  }
 
  wrefresh(wBio);
- char ch;
+ int ch;
  bool activating = true;
  do {
   bionic *tmp = NULL;

--- a/ranged.cpp
+++ b/ranged.cpp
@@ -457,7 +457,6 @@ std::vector<point> game::target(point& tar, const zaimoni::gdi::box<point>& boun
  }
 
  wrefresh(w_target);
- char ch;
  bool snap_to_target = option_table::get()[OPT_SNAP_TO_TARGET];
 // The main loop.
  do {
@@ -524,7 +523,7 @@ std::vector<point> game::target(point& tar, const zaimoni::gdi::box<point>& boun
   wrefresh(w_terrain);
   wrefresh(w_status);
   refresh();
-  ch = input();
+  int ch = input();
   point dir(get_direction(ch));
   if (dir.x != -2 && ch != '.') {	// Direction character pressed
    monster* const m_at = mon(tar);

--- a/veh_interact.cpp
+++ b/veh_interact.cpp
@@ -78,7 +78,7 @@ void veh_interact::exec ()
     bool finish = false;
     while (!finish)
     {
-        char ch = input(); // See keypress.h
+        int ch = input(); // See keypress.h
         int dx, dy;
         get_direction (dx, dy, ch);
         if (ch == KEY_ESCAPE) finish = true;
@@ -197,7 +197,7 @@ void veh_interact::do_install(int reason)
             mvwprintz(w_msg, 1, 21, has_skill2? c_ltgreen : c_red, "%d", dif_eng);
         }
         wrefresh (w_msg);
-        char ch = input(); // See keypress.h
+        int ch = input(); // See keypress.h
         int dx, dy;
         get_direction (dx, dy, ch);
         if ((ch == '\n' || ch == ' ') && has_comps && has_skill && has_skill2)
@@ -267,7 +267,7 @@ void veh_interact::do_repair(int reason)
             mvwprintz(w_msg, 1, 28, has_comps? c_ltgreen : c_red, item::types[itm]->name.c_str());            
         }
         wrefresh (w_msg);
-        char ch = input(); // See keypress.h
+        int ch = input(); // See keypress.h
         int dx, dy;
         get_direction (dx, dy, ch);
         if ((ch == '\n' || ch == ' ') && has_comps && (veh->parts[sel_part].hp > 0 || has_wrench) && has_skill)
@@ -357,7 +357,7 @@ void veh_interact::do_remove(int reason)
         werase (w_parts);
         veh->print_part_desc (w_parts, 0, winw2, cpart, pos);
         wrefresh (w_parts);
-        char ch = input(); // See keypress.h
+        int ch = input(); // See keypress.h
         int dx, dy;
         get_direction (dx, dy, ch);
         if (ch == '\n' || ch == ' ')

--- a/wish.cpp
+++ b/wish.cpp
@@ -12,7 +12,7 @@ void game::wish()
  WINDOW* const w_list = newwin(VIEW, 30, 0,  0);
  WINDOW* const w_info = newwin(VIEW, 50, 0, 30);
  int a = 0, shift = 0, result_selected = 0;
- char ch = '.';
+ int ch = '.';
  bool search = false, found = false;
  std::string pattern;
  std::string info;
@@ -160,7 +160,7 @@ void game::monster_wish()
  WINDOW* const w_list = newwin(VIEW, 30, 0,  0);
  WINDOW* const w_info = newwin(VIEW, 50, 0, 30);
  int a = 0, shift = 1, result_selected = 0;
- char ch = '.';
+ int ch = '.';
  bool search = false, found = false, friendly = false;
  std::string pattern;
  std::string info;
@@ -301,7 +301,7 @@ void game::mutation_wish()
  WINDOW* const w_list = newwin(VIEW, 30, 0,  0);
  WINDOW* const w_info = newwin(VIEW, 50, 0, 30);
  int a = 0, shift = 0, result_selected = 0;
- long ch = '.';
+ int ch = '.';
  bool search = false, found = false;
  std::string pattern;
  std::string info;


### PR DESCRIPTION
Variables using getch() (and related functions that return getch() derived values or have an argument for key input) don't consistently use the same type.  In some cases, a long is used which isn't a problem normally but can cause warnings (long is also an inconsistent size between Windows and 64-bit Linux so it's best to avoid.)  Mostly char is used which can't properly handle special key constant values over 127.

For now, these changes just clean up some warnings but in the future it could help with handing input of special keys.

Tested changes on Linux (compile & running the game), and verified compile on Msys2/MinGW
