### PR TITLE
accidental fall-through bug fixes

### DIFF
--- a/iuse.cpp
+++ b/iuse.cpp
@@ -2015,6 +2015,7 @@ void iuse::artifact(game *g, player *p, item *it, bool t)
 	 if (monster* const m_at = g->mon(x,y)) m_at->add_effect(ME_STUNNED, rng(5, 15));
     }
    }
+   break;
 
   case AEA_ENTRANCE:
    for (int x = p->pos.x - 8; x <= p->pos.x + 8; x++) {

--- a/mapgen.cpp
+++ b/mapgen.cpp
@@ -4948,10 +4948,10 @@ void map::draw_map(oter_id terrain_type, oter_id t_north, oter_id t_east,
 
   if (t_above == ot_slimepit_down) {
    switch (rng(1, 4)) {
-    case 1: ter(rng(0, 2), rng(0, 2)) = t_slope_up;
-    case 2: ter(rng(0, 2), SEEY * 2 - rng(1, 3)) = t_slope_up;
-    case 3: ter(SEEX * 2 - rng(1, 3), rng(0, 2)) = t_slope_up;
-    case 4: ter(SEEX * 2 - rng(1, 3), SEEY * 2 - rng(1, 3)) = t_slope_up;
+    case 1: ter(rng(0, 2), rng(0, 2)) = t_slope_up; break;
+    case 2: ter(rng(0, 2), SEEY * 2 - rng(1, 3)) = t_slope_up; break;
+    case 3: ter(SEEX * 2 - rng(1, 3), rng(0, 2)) = t_slope_up; break;
+    case 4: ter(SEEX * 2 - rng(1, 3), SEEY * 2 - rng(1, 3)) = t_slope_up; break;
    }
   }
 


### PR DESCRIPTION
This type of bug fix is a bit annoying because it's hard to be 100% sure of the original intent but they do look like cases where 'break' was missed.  The other type of case where fall-through is intended, the [[fallthrough]] attribute should be used.