### PR TITLE
partial fix for 'npc::execute_action will fail' exception

### DIFF
--- a/npcmove.cpp
+++ b/npcmove.cpp
@@ -1934,10 +1934,18 @@ void npc::set_destination(game *g)
 			options.push_back(ot_s_library_north);
  }
 
- oter_id dest_type = options[rng(0, options.size() - 1)];
-
  const auto om = overmap::toOvermap(GPSpos);
- g->cur_om.find_closest(om.second, dest_type, 4, goal);
+
+ shuffle_contents(options);
+ for (auto dest_type : options) {
+  if (g->cur_om.find_closest(om.second, dest_type, 4, goal)) { return; }
+ }
+
+ // FIXME - leaving this function without setting a destination will
+ // result in npc::move() throwing an exception later on.  Either this
+ // function needs to always set a destination (with some sort of
+ // secondary policy like picking the closest destination) or
+ // long_term_goal_action() needs to return some other action.
 }
 
 void npc::go_to_destination(game *g)

--- a/rng.h
+++ b/rng.h
@@ -1,9 +1,23 @@
-#ifndef _RNG_H_
-#define _RNG_H_
+#ifndef RNG_H
+#define RNG_H
+
+#include <algorithm>
+
 long rng(long low, long high);
 int dice(int number, int sides);
 
-inline bool one_in(int chance) { return (chance <= 1 || rng(0, chance - 1) == 0); };
+inline bool one_in(int chance) { return (chance <= 1 || rng(0, chance - 1) == 0); }
 inline bool rng_lte(long low, long high, long ub) { return (high <= ub) ? true : (ub < low ? false : rng(low, high) <= ub); }
+
+template<class ContainerType>
+void shuffle_contents(ContainerType& v)
+{
+    if (std::empty(v)) { return; }
+    auto s = std::size(v) - 1;
+    for (decltype(s) i = 0; i < s; ++i) {
+        using std::swap;
+        swap(v[i], v[rng(i,s)]);
+    }
+}
 
 #endif


### PR DESCRIPTION
actual changes:
- added function 'shuffle_container()' to randomizing order of container contents
- set_destination() will try all possible destinations for npc need target instead of just one

This is just the first part of a fix for the 'npc::execute_action will fail' exceptions I see almost every game.
There needs to be some sort of secondary policy in set_destination() if all the initial possible destinations are out of range.
Perhaps we should pick the closest one or make the initial choice not ignore destinations over 4 away but instead use the distance as some sort of weighting to the chance to pick it - there are a lot of possibilities here.

Anyways feel free to change whatever - I just want to get rid of the exception. :)