### PR TITLE
prevent bad 'maps.txt' from being created if game is immediately quit…

### DIFF
--- a/mapbuffer.cpp
+++ b/mapbuffer.cpp
@@ -32,6 +32,7 @@ submap* mapbuffer::lookup_submap(const tripoint& src)
 
 void mapbuffer::save()
 {
+ if (submaps.empty()) return;
 
  DECLARE_AND_ACID_OPEN(std::ofstream, fout, MAP_FILE, return;)
 


### PR DESCRIPTION
… the first time it is started
---
mapbuffer::load() really should be improved to either use num_submaps or handle thrown exceptions to prevent a crash (or both) - this is just the easiest change that prevents a bad maps.txt in the first place
