### PR TITLE
compile & warning fixes

### DIFF
--- a/iuse.cpp
+++ b/iuse.cpp
@@ -777,7 +777,7 @@ void iuse::extinguisher(game *g, player *p, item *it, bool t)
   if (g->u_see(m_at)) messages.add("The %s is sprayed!", m_at->name().c_str());
   if (m_at->made_of(LIQUID)) {
    if (g->u_see(m_at)) messages.add("The %s is frozen!", m_at->name().c_str());
-   if (m_at->hurt(rng(20, 60))) g->kill_mon(*m_at, &p);
+   if (m_at->hurt(rng(20, 60))) g->kill_mon(*m_at, p);
    else m_at->speed /= 2;
   }
  }
@@ -1732,7 +1732,7 @@ void iuse::tazer(game *g, player *p, item *it, bool t)
   messages.add("You shock the %s!", z->name().c_str());
   int shock = rng(5, 25);
   z->moves -= shock * 100;
-  if (z->hurt(shock)) g->kill_mon(*z, &p);
+  if (z->hurt(shock)) g->kill_mon(*z, p);
   return;
  }
  

--- a/vehicle.cpp
+++ b/vehicle.cpp
@@ -379,7 +379,7 @@ bool vehicle::any_boarded_parts() const
 {
 	for (const auto& part : parts) {
 		if (!part.has_flag(vpf_seat)) continue;
-        assert(parts[p].get_passenger(global()) == parts[p].get_passenger(GPSpos));
+		assert(part.get_passenger(global()) == part.get_passenger(GPSpos));
 		if (part.get_passenger(global())) return true;
 	}
 	return false;

--- a/vehicle.cpp
+++ b/vehicle.cpp
@@ -1017,7 +1017,7 @@ int vehicle::part_collision (int vx, int vy, int part, point dest)
             z->hurt(dam);
             if (vel2 > rng (5, 30))
                 g->fling_player_or_monster(nullptr, z, move.dir() + angle, vel2 / 100);
-            if (z->hp < 1) g->kill_mon (*z, pl_ctrl);
+            if (z->hp < 1) g->kill_mon(*z, pl_ctrl);
         } else {
             ph->hitall (g, dam, 40);
             if (vel2 > rng (5, 30))


### PR DESCRIPTION
Minor fixes - see individual commits for details.
Some possible follow ups:
* enable assert() on MSVC compiles
* function overloads (especially with bool args) are easy to mess up - renaming one of the game::kill_mon() methods would make things safer (found the problem because of a compile warning on Linux)