### PR TITLE
compile error fixes

### DIFF
--- a/GPS_loc.hpp
+++ b/GPS_loc.hpp
@@ -8,8 +8,8 @@
 #include <optional>
 
 class vehicle;
-enum ter_id;
-enum trap_id;
+enum ter_id : int;
+enum trap_id : int;
 
 // normalized range for GPS_loc.second is 0..SEE-1, 0..SEE-1
 // reality_bubble_loc.second == GPS_loc.second for normalized GPS_loc corresponding to reality_bubble_loc

--- a/itypedef.cpp
+++ b/itypedef.cpp
@@ -18,7 +18,7 @@ const item item::null(null_type ,0);	// this must be in the same file as null_ty
 
 std::string item_drop_spec::to_s() const
 {
-	const itype& const info = *item::types[what];
+	const itype& info = *item::types[what];
 	std::string desc(std::to_string(qty));
 	desc += " ";
 	// for now, hard-code the one-in processing mode

--- a/mapdata.h
+++ b/mapdata.h
@@ -29,7 +29,7 @@ enum t_flag {
  num_t_flags   // MUST be last
 };
 
-enum ter_id {
+enum ter_id : int {
 t_null = 0,
 t_hole,	// Real nothingness; makes you fall a z-level
 // Ground

--- a/trap.h
+++ b/trap.h
@@ -6,7 +6,7 @@
 class monster;
 class game;
 
-enum trap_id {
+enum trap_id : int {
  tr_null,
  tr_bubblewrap,
  tr_beartrap,


### PR DESCRIPTION
Additionally, **trap_handler.hpp** is missing so compiles will fail until this is added.

g++ -Wall -Wextra -Wno-switch -Wno-sign-compare -Wno-unused-variable -Wno-maybe-uninitialized -Wno-unused-but-set-variable -Wno-unused-function -Wno-unused-parameter   -O3 -std=gnu++17 -MMD -MP -DCATACLYSM -c trapdef.cpp -o obj_cataclysm/trapdef.o
trapdef.cpp:3:10: fatal error: trap_handler.hpp: No such file or directory
    3 | #include "trap_handler.hpp"
      |          ^~~~~~~~~~~~~~~~~~
