### PR TITLE
linux compile fix

### DIFF
--- a/socrates-daimon.cpp
+++ b/socrates-daimon.cpp
@@ -17,6 +17,7 @@
 
 #include <fstream>
 #include <filesystem>
+#include <algorithm>
 
 using namespace cataclysm;
 


### PR DESCRIPTION
algorithm include needed for std::sort()